### PR TITLE
Added conditional include for malloc.h

### DIFF
--- a/src/lsh/sources/headers.h
+++ b/src/lsh/sources/headers.h
@@ -31,7 +31,9 @@
 #include "NearNeighbors.h"
 
 #ifdef DEBUG_MEM
+#if !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #endif
 
 #ifdef DEBUG_TIMINGS


### PR DESCRIPTION
To make the build compatible to Macs, I added a condition to the include of malloc.h in the header as suggested by skyhover in issue #5.
