### PR TITLE
Dockerizes Deckard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# TODO: move from python2 to python3
+FROM python:2
+
+USER root
+
+WORKDIR /deckard
+
+RUN apt-get update -y
+
+RUN apt-get update -y && apt-get install -y \
+	git \
+	make \
+	gcc \
+	g++ \
+	cmake \
+	libtool \
+	autoconf \
+	automake \
+	libltdl-dev \
+	bison \
+	flex
+
+COPY . .
+
+WORKDIR /deckard/src/main
+
+RUN ./build.sh
+


### PR DESCRIPTION
This PR adds a Dockerfile to Deckard so that its binaries can be reused 
across various containers and architectures. 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
